### PR TITLE
Add primitive cache on Promise\Declaration\Extractor\Methods::getExtendedMethodNodes

### DIFF
--- a/src/Promise/Declaration/Extractor/Methods.php
+++ b/src/Promise/Declaration/Extractor/Methods.php
@@ -284,7 +284,8 @@ final class Methods
                 $this->traverser->traverse(
                     $this->parser->parse(
                         file_get_contents($fileName)
-                    ), $methods
+                    ),
+                    $methods
                 );
 
                 self::$nodesByFileNameCache[$fileName] = $methods->getMethods();
@@ -293,7 +294,7 @@ final class Methods
         return self::$nodesByFileNameCache[$fileName];
     }
 
-    public static function resetNodesCache() : void
+    public static function resetNodesCache(): void
     {
         self::$nodesByFileNameCache = [];
     }

--- a/tests/Promise/ProxyPrinter/Methods/MethodsTest.php
+++ b/tests/Promise/ProxyPrinter/Methods/MethodsTest.php
@@ -65,6 +65,37 @@ class MethodsTest extends BaseProxyPrinterTest
      * @throws ReflectionException
      * @throws ProxyFactoryException
      * @throws Throwable
+     */
+    public function testPromiseMethodsCache(): void
+    {
+        $classname = Fixtures\EntityWithMethods::class;
+        $as = self::NS . __CLASS__ . __LINE__;
+        $reflection = new ReflectionClass($classname);
+
+        $parent = Declarations::createParentFromReflection($reflection);
+        $class = Declarations::createClassFromName($as, $parent);
+
+        $outputFirst = $this->make($reflection, $class, $parent);
+        $fileName = $reflection->getFileName();
+        rename($fileName, $fileName . '_old');
+        $outputSecond = $this->make($reflection, $class, $parent);
+        rename($fileName . '_old', $fileName);
+        //get information from cache. Result same inspire that file was changed
+        $this->assertEquals($outputFirst, $outputSecond);
+
+        Extractor\Methods::resetNodesCache();
+        rename($fileName, $fileName . '_old');
+        Extractor\Methods::resetNodesCache();
+        $outputSecond = $this->make($reflection, $class, $parent);
+        rename($fileName . '_old', $fileName);
+        //get information when cache was cleared. Result not same because of file changing
+        $this->assertNotEquals($outputFirst, $outputSecond);
+    }
+
+    /**
+     * @throws ReflectionException
+     * @throws ProxyFactoryException
+     * @throws Throwable
      * @throws Throwable
      */
     public function testInheritedMethods(): void


### PR DESCRIPTION
`$this->parser->parse(...` - very expensive operation. Same class can be parsed more than once. Thats why caching result in static property can give great performance impact in some cases.
But I am not sure that it is good strategy for future. Maybe better prepare proxy object in startup (for examble using some console command) and in runtime even not run `getExtendedMethodNodes` in general.
I am ready to discus variants and will try to help with realisation.